### PR TITLE
pkgRecommendations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: r
 cache: packages
 warnings_are_errors: false
+r_github_packages: stephlocke/pkgRecommendations
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: r
 cache: packages
 warnings_are_errors: false
-r_github_packages: stephlocke/pkgRecommendations
 addons:
   apt:
     packages:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,39 +1,12 @@
 Package: Rtraining
 Title: Training Materials on R
-Version: 1.1.22
+Version: 1.1.23
 Authors@R: person("Steph", "Locke",   email="stephanie.g.locke@gmail.com", role = c("aut", "cre"))
 Description: From presentations to hands-on learning materials, this package
     contains stuff Steph thinks you should know about!
 Depends:
-    R (>= 3.1.2),
-    devtools,
-    data.table,
-    dplyr,
-    DiagrammeR,
-    shiny,
-    Hmisc,
-    foreach,
-    memisc,
-    optiRum,
-    readxl,
-    readr,
-    RODBC,
-    testthat,
-    ezknitr,
-    rmarkdown,
-    knitr,
-    leaflet,
-    dygraphs,
-    plotly,
-    DT,
-    revealjs,
-    vegalite,
-    testthat,
-    lubridate,
-    stringi,
-    ggmap,
-    xts,
-    urltools
+    R (>= 3.1.2)
+Remotes: stephlocke/pkgRecommendations
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,8 @@ Description: From presentations to hands-on learning materials, this package
     contains stuff Steph thinks you should know about!
 Depends:
     R (>= 3.1.2)
+Suggests:
+    knitr
 Remotes: stephlocke/pkgRecommendations
 Imports: pkgRecommendations
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,10 +6,11 @@ Description: From presentations to hands-on learning materials, this package
     contains stuff Steph thinks you should know about!
 Depends:
     R (>= 3.1.2)
+Imports: 
+    pkgRecommendations
 Suggests:
     knitr
 Remotes: stephlocke/pkgRecommendations
-Imports: pkgRecommendations
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Description: From presentations to hands-on learning materials, this package
 Depends:
     R (>= 3.1.2)
 Remotes: stephlocke/pkgRecommendations
+Imports: pkgRecommendations
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -1,4 +1,5 @@
 context("Formats")
+library(rmarkdown)
 
 
 test_that("formats successfully produce a document", {


### PR DESCRIPTION
Move to pkgRecomendations to hold the long package manifest used in Rtraining. The packages constitute recommendations and I wanted to make it easier for people to just get the packages. This is part of ongoing effort to reduce the scope of the Rtraining module.
